### PR TITLE
Fix explicit subs argument call

### DIFF
--- a/paramspider.py
+++ b/paramspider.py
@@ -38,7 +38,7 @@ def main():
     parser.add_argument('-r', '--retries', help='Specify number of retries for 4xx and 5xx errors', default=3)
     args = parser.parse_args()
 
-    if args.subs == True:
+    if args.subs == True or " True":
         url = f"https://web.archive.org/cdx/search/cdx?url=*.{args.domain}/*&output=txt&fl=original&collapse=urlkey&page=/"
     else:
         url = f"https://web.archive.org/cdx/search/cdx?url={args.domain}/*&output=txt&fl=original&collapse=urlkey&page=/"


### PR DESCRIPTION
After a quick look at the program's features, I started using `--subs` and did not get the expected result. So I provided the fix to avoid additional parsing under boolean stuff.
<img width="1285" alt="subs_arg" src="https://user-images.githubusercontent.com/18244131/111983669-f767b680-8b3c-11eb-9ee9-4facedf90f74.png">
<img width="1285" alt="subs_arg_2" src="https://user-images.githubusercontent.com/18244131/111983697-fdf62e00-8b3c-11eb-9a63-a8326f0ce176.png">
