### PR TITLE
A new argument added, "--silent".

### DIFF
--- a/paramspider.py
+++ b/paramspider.py
@@ -25,7 +25,6 @@ def main():
                             
                            \u001b[32m - coded with <3 by Devansh Batham\u001b[0m 
     """
-    print(banner)
 
     parser = argparse.ArgumentParser(description='ParamSpider a parameter discovery suite')
     parser.add_argument('-d','--domain' , help = 'Domain name of the taget [ex : hackerone.com]' , required=True)
@@ -35,8 +34,12 @@ def main():
     parser.add_argument('-o','--output' , help = 'Output file name [by default it is \'domain.txt\']')
     parser.add_argument('-p','--placeholder' , help = 'The string to add as a placeholder after the parameter name.', default = "FUZZ")
     parser.add_argument('-q', '--quiet', help='Do not print the results to the screen', action='store_true')
+    parser.add_argument("--silent", help="Print only the results to the screen.", action='store_true')
     parser.add_argument('-r', '--retries', help='Specify number of retries for 4xx and 5xx errors', default=3)
     args = parser.parse_args()
+
+    if args.silent != True:
+        print(banner)
 
     if args.subs == True or " True":
         url = f"https://web.archive.org/cdx/search/cdx?url=*.{args.domain}/*&output=txt&fl=original&collapse=urlkey&page=/"
@@ -66,31 +69,38 @@ def main():
     else: 
          black_list = [] # for blacklists
     if args.exclude:
-        print(f"\u001b[31m[!] URLS containing these extensions will be excluded from the results   : {black_list}\u001b[0m\n")
+        if args.silent != True:
+            print(f"\u001b[31m[!] URLS containing these extensions will be excluded from the results   : {black_list}\u001b[0m\n")
     
     final_uris = extractor.param_extract(response , args.level , black_list, args.placeholder)
     save_it.save_func(final_uris , args.output , args.domain)
 
     if not args.quiet:
-        print("\u001b[32;1m")
+        if args.silent != True:
+            print("\u001b[32;1m")
         print('\n'.join(final_uris))
-        print("\u001b[0m")
+        if args.silent != True:
+            print("\u001b[0m")
 
-    print(f"\n\u001b[32m[+] Total number of retries:  {retries-1}\u001b[31m")
-    print(f"\u001b[32m[+] Total unique urls found : {len(final_uris)}\u001b[31m")
+    if args.silent != True:
+        print(f"\n\u001b[32m[+] Total number of retries:  {retries-1}\u001b[31m")
+        print(f"\u001b[32m[+] Total unique urls found : {len(final_uris)}\u001b[31m")
     if args.output:
         if "/" in args.output:
-            print(f"\u001b[32m[+] Output is saved here :\u001b[31m \u001b[36m{args.output}\u001b[31m" )
+            if args.silent != True:
+                print(f"\u001b[32m[+] Output is saved here :\u001b[31m \u001b[36m{args.output}\u001b[31m" )
 
         else:
-            print(f"\u001b[32m[+] Output is saved here :\u001b[31m \u001b[36moutput/{args.output}\u001b[31m" )
+            if args.silent != True:
+                print(f"\u001b[32m[+] Output is saved here :\u001b[31m \u001b[36moutput/{args.output}\u001b[31m" )
     else:
-        print(f"\u001b[32m[+] Output is saved here   :\u001b[31m \u001b[36moutput/{args.domain}.txt\u001b[31m")
-    print("\n\u001b[31m[!] Total execution time      : %ss\u001b[0m" % str((time.time() - start_time))[:-12])
+        if args.silent != True:
+            print(f"\u001b[32m[+] Output is saved here   :\u001b[31m \u001b[36moutput/{args.domain}.txt\u001b[31m")
+    if args.silent != True:
+        print("\n\u001b[31m[!] Total execution time      : %ss\u001b[0m" % str((time.time() - start_time))[:-12])
 
 
 
 
 if __name__ == "__main__":
     main()
-    


### PR DESCRIPTION
This argument print only the results to the screen, to be used as a pipeline without interference of another things in output.
Exemple: `python3 paramspider.py -d hackerone.com --silent | qsreplace "'><img src=x onerror=confirm(1)>"`