### PR TITLE
Added pyopenssl==22.1.0 to avoid runtime error.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ chardet==3.0.4
 idna==2.9
 requests==2.23.0
 urllib3==1.25.8
+pyopenssl==22.1.0


### PR DESCRIPTION
Python will try to access some functions of this library, if it couldn't it it will throw an exception error `AttributeError: module 'lib' has no attribute 'SSL_CTX_set_ecdh_auto'` and `exit 1`.