### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ setup(
         ]
     },
     license='MIT',
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding='utf-8').read(),
     long_description_content_type='text/markdown'
 )


### PR DESCRIPTION
fix decoding error
By specifying encoding='utf-8' when opening the 'README.md' file, you should be able to read the file without encountering a UnicodeDecodeError.