### PR TITLE
 Add -dp / --disable-placeholder flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Here are a few examples of how to use `paramspider`:
 - Disable updating parameter values with a placeholder:
 
  ```sh
-   paramspider -d example.com -db'
+   paramspider -d example.com -db
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ Here are a few examples of how to use `paramspider`:
    paramspider -d example.com -p '"><h1>reflection</h1>'
   ```
 
+- Disable updating parameter values with a placeholder:
+
+ ```sh
+   paramspider -d example.com -db'
+```
+
 ## Contributing
 
 Contributions are welcome! If you'd like to contribute to `paramspider`, please follow these steps:

--- a/paramspider/main.py
+++ b/paramspider/main.py
@@ -147,7 +147,7 @@ def main():
     parser.add_argument("-s", "--stream", action="store_true", help="Stream URLs on the terminal.")
     parser.add_argument("--proxy", help="Set the proxy address for web requests.", default=None)
     parser.add_argument("-p", "--placeholder", help="Placeholder for parameter values", default="FUZZ")
-    parser.add_argument("-db", "--disable-placeholder", action="store_true", help="Disable updating parameter values with the default placeholder.")
+    parser.add_argument("-db", "--disable-placeholder", action="store_true", help="Disable updating parameter values with a placeholder.")
     args = parser.parse_args()
 
     if not args.domain and not args.list:

--- a/paramspider/main.py
+++ b/paramspider/main.py
@@ -147,7 +147,7 @@ def main():
     parser.add_argument("-s", "--stream", action="store_true", help="Stream URLs on the terminal.")
     parser.add_argument("--proxy", help="Set the proxy address for web requests.", default=None)
     parser.add_argument("-p", "--placeholder", help="Placeholder for parameter values", default="FUZZ")
-    parser.add_argument("-db", "--disable-placeholder", action="store_true", help="Disable updating parameter values with a placeholder.")
+    parser.add_argument("-dp", "--disable-placeholder", action="store_true", help="Disable updating parameter values with a placeholder.")
     args = parser.parse_args()
 
     if not args.domain and not args.list:


### PR DESCRIPTION
This pull request introduces a new command-line flag, `--disable-placeholder` (short form: `-dp`), to the paramspider script. When this flag is provided, the script will refrain from updating parameter values with the default placeholder, allowing users to retain original query parameters.

### Changes:

- Added support for the `--disable-placeholder` flag.
- Updated the script to preserve original query parameters when the flag is used.
- Added an example of using the `--disable-placeholder` flag to the README.