### PR TITLE
encoding to utf-8 - solving the issue for installing the requirements when using "pip install ."

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,6 @@ setup(
         ]
     },
     license='MIT',
-    long_description=open('README.md').read(),
+    long_description=open('README.md', encoding='utf-8').read(),
     long_description_content_type='text/markdown'
 )


### PR DESCRIPTION
older one: 
`long_description=open('README.md').read(),`

This line is trying to read the README.md file using the default encoding, but it seems like the README.md file contains some characters that can't be decoded using the default encoding. So using the utf-8 encoding instead,

`long_description=open('README.md', encoding='utf-8').read(),`