### PR TITLE
Fix Continuation Problem

### DIFF
--- a/paramspider/client.py
+++ b/paramspider/client.py
@@ -64,4 +64,4 @@ def fetch_url_content(url,proxy):
             sys.exit()
 
     logging.error(f"Failed to fetch URL {url} after {MAX_RETRIES} retries.")
-    sys.exit()
+    return None

--- a/paramspider/main.py
+++ b/paramspider/main.py
@@ -93,6 +93,8 @@ def fetch_and_clean_urls(domain, extensions, stream_output,proxy, placeholder):
     logging.info(f"{Fore.YELLOW}[INFO]{Style.RESET_ALL} Fetching URLs for {Fore.CYAN + domain + Style.RESET_ALL}")
     wayback_uri = f"https://web.archive.org/cdx/search/cdx?url={domain}/*&output=txt&collapse=urlkey&fl=original&page=/"
     response = client.fetch_url_content(wayback_uri,proxy)
+    if response == None:
+        return
     urls = response.text.split()
     
     logging.info(f"{Fore.YELLOW}[INFO]{Style.RESET_ALL} Found {Fore.GREEN + str(len(urls)) + Style.RESET_ALL} URLs for {Fore.CYAN + domain + Style.RESET_ALL}")


### PR DESCRIPTION
When i use paramspider -L domains.txt. and for some reason if there was a error fetching a URL even after 3rd retry, the code exit and stop scanning for other URL.

This commit allows to skip the url which have error fetching after 3rd retry, and move on to other URL on the list, for me its work.